### PR TITLE
Add tofu function and tests for template parsing

### DIFF
--- a/src/tofu.spec.ts
+++ b/src/tofu.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { tofu } from "./tofu.js";
+
+describe("tofu", () => {
+  it("should parse template", () => {
+    expect(tofu("Hello {name}!", { name: "World" })).toBe("Hello World!");
+  });
+
+  it("should parse template with multiple variables", () => {
+    expect(
+      tofu("Hello {name}! {name} is {age} years old.", {
+        name: "World",
+        age: 42,
+      })
+    ).toBe("Hello World! World is 42 years old.");
+  });
+
+  it("should parse template with nested variables", () => {
+    expect(
+      tofu("Hello, {name.first} {name.last}!", {
+        name: { first: "John", last: "McClane" },
+      })
+    ).toBe("Hello, John McClane!");
+  });
+});

--- a/src/tofu.ts
+++ b/src/tofu.ts
@@ -1,0 +1,21 @@
+export function tofu(
+  template: string, // the template string
+  data: Record<string, unknown> // the values
+): string {
+  return template.replace(
+    /{ *([^} ]+) *}/g, // searches for { variable_name } to replace
+    function (
+      // the replacer function
+      match: string, // no use here. it holds the entire "{ variable_name }" string
+      key: string // we will use this instead, it holds "variable_name"
+    ): string {
+      let value: unknown = data; // re-assign the placeholder to values
+      key.replace(/[^.]+/g, function (subKey: string): string {
+        // find all the key names
+        value = (value as Record<string, unknown>)[subKey]; // one by one until it's reduced to the one we are looking for
+        return subKey; // return subKey to avoid TypeScript error
+      });
+      return String(value); // return this value to be replaced
+    }
+  );
+}


### PR DESCRIPTION
This pull request introduces a new `tofu` function which is responsible for parsing templates and replacing variables with the provided data. It can handle simple variables, multiple variables, and nested variables. The implementation is accompanied by a test suite that covers these use cases.

Changes:

- Add `tofu` function in `tofu.ts`:
  - The function takes a template string and a data object as input.
  - It uses a regular expression to search for placeholder variables in the template.
  - It replaces the placeholders with the corresponding values from the data object.
  - The function returns the processed template string.

- Add test suite `tofu.spec.ts`:
  - Test case for parsing a template with a single variable.
  - Test case for parsing a template with multiple variables.
  - Test case for parsing a template with nested variables.

Please review the implementation and let me know if there are any suggestions or changes needed.