### PR TITLE
Add prompt parsing with variable substitution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * as prompts from "./prompts";
+export * from "./parser";

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { parsePrompt, parsePromptVariables } from "./parser";
+
+describe("parsePromptVariables", () => {
+  it("should parse variables", () => {
+    expect(
+      parsePromptVariables(
+        {
+          variables: {
+            name: {
+              name: "name",
+              type: "string",
+              description: "The name",
+              required: true,
+            },
+            age: {
+              name: "age",
+              type: "string",
+              description: "The age",
+              required: false,
+              default: "42",
+            },
+          },
+        },
+        { name: "World" }
+      )
+    ).toEqual({ name: "World", age: "42" });
+  });
+
+  it("should throw if required variable is missing", () => {
+    expect(() =>
+      parsePromptVariables(
+        {
+          variables: {
+            name: {
+              name: "name",
+              type: "string",
+              description: "The name",
+              required: true,
+            },
+            age: {
+              name: "age",
+              type: "string",
+              description: "The age",
+              required: false,
+              default: "42",
+            },
+          },
+        },
+        {}
+      )
+    ).toThrowError("Missing required variable name");
+  });
+});
+
+describe("parsePrompt", () => {
+  it("should parse prompt", () => {
+    expect(
+      parsePrompt(
+        {
+          name: "test",
+          description: "Test",
+          message: "Hello {name}!",
+          variables: {
+            name: {
+              name: "name",
+              type: "string",
+              description: "The name",
+              required: true,
+            },
+          },
+        },
+        { name: "World" }
+      )
+    ).toEqual({
+      messages: [
+        {
+          role: "system",
+          content: "Hello World!",
+        },
+      ],
+    });
+  });
+
+  it("should parse prompt with multiple messages", () => {
+    expect(
+      parsePrompt(
+        {
+          name: "test",
+          description: "Test",
+          message: [
+            {
+              role: "system",
+              content: "Hello, {name}!",
+            },
+            {
+              role: "system",
+              content: "How are you, {name}?",
+            },
+          ],
+          variables: {
+            name: {
+              name: "name",
+              type: "string",
+              description: "The name",
+              required: true,
+            },
+          },
+        },
+        { name: "World" }
+      )
+    ).toEqual({
+      messages: [
+        {
+          role: "system",
+          content: "Hello, World!",
+        },
+        {
+          role: "system",
+          content: "How are you, World?",
+        },
+      ],
+    });
+  });
+});

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,49 @@
+import { ChatCompletionRequestMessage } from "openai";
+import { tofu } from "./tofu";
+import { Prompt, PromptResult } from "./types";
+
+export function parsePromptVariables(
+  prompt: Pick<Prompt, "variables">,
+  providedVariables: Record<string, string>
+) {
+  const output = {} as Record<string, string>;
+  for (const variableName in prompt.variables) {
+    const variable = prompt.variables[variableName];
+    const providedValue = providedVariables[variableName];
+    if (variable.required && !providedValue) {
+      throw new Error(`Missing required variable ${variableName}`);
+    }
+    output[variableName] = providedValue ?? variable.default;
+  }
+
+  return output;
+}
+
+export function parsePrompt(
+  prompt: Prompt,
+  variables: Record<string, string>
+): PromptResult {
+  const parsedVariables = parsePromptVariables(prompt, variables);
+
+  const messages: ChatCompletionRequestMessage[] = Array.isArray(prompt.message)
+    ? prompt.message
+    : [
+        {
+          role: "system",
+          content: prompt.message,
+        },
+      ];
+
+  const parsedMessages = messages.map((message) => {
+    const parsedContent = tofu(message.content, parsedVariables);
+    return {
+      ...message,
+      role: message.role ?? "system",
+      content: parsedContent,
+    };
+  });
+
+  return {
+    messages: parsedMessages,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,21 +1,23 @@
-import { ChatCompletionResponseMessage } from "openai";
+import {
+  ChatCompletionRequestMessage,
+  ChatCompletionResponseMessage,
+} from "openai";
 
 export type PromptVariable = {
   name: string;
   type: string;
   description: string;
-  default: string;
+  default?: string;
   required: boolean;
 };
 
 export type Prompt = {
   name: string;
   description: string;
-  message: string;
+  message: string | ChatCompletionRequestMessage[];
   variables: Record<string, PromptVariable>;
 };
 
 export type PromptResult = {
-  name: string;
   messages: ChatCompletionResponseMessage[];
 };


### PR DESCRIPTION
This pull request adds the functionality to parse prompts with variable substitution. The following changes have been made:

1. Added two new functions `parsePromptVariables` and `parsePrompt` in `src/parser.ts`.
   - `parsePromptVariables` takes a prompt and provided variables as input and returns the parsed variables with their default values if not provided.
   - `parsePrompt` takes a prompt and variables as input, and returns a `PromptResult` with messages after variable substitution.

2. Modified `src/types.ts` to update the `Prompt` and `PromptResult` types.
   - Changed the `message` field in `Prompt` type to accept an array of `ChatCompletionRequestMessage` objects along with a single string.
   - Removed the `name` field from the `PromptResult` type as it is not used.

3. Added tests for the new functions in `src/parser.spec.ts`.

**Test Plan:**

1. Ensure all the tests in `src/parser.spec.ts` pass.
2. Manually test the parsing functionality with different prompts and variable inputs to ensure correct variable substitution and error handling.