### PR TITLE
Add npm package publishing to existing GitHub Packages publishing workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,3 +1,9 @@
+inputs:
+  npm-registry:
+    description: 'The npm registry to use'
+    required: false
+    default: 'https://registry.npmjs.org'
+
 runs:
   using: "composite"
   steps:
@@ -9,7 +15,7 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
-        registry-url: 'https://npm.pkg.github.com'
+        registry-url: ${{ inputs.npm-registry }}
         cache: 'pnpm'
     - run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,3 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
 name: Node.js Package
 
 on:
@@ -13,19 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          registry-url: 'https://npm.pkg.github.com'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm test
       - run: pnpm check-types
+      - run: pnpm build
 
   publish-gpr:
     needs: build
@@ -35,18 +23,19 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          registry-url: 'https://npm.pkg.github.com'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+        with:
+          npm-registry: https://npm.pkg.github.com
       - run: pnpm build
       - run: npm publish
         env:
@@ -36,6 +38,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - run: pnpm build
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -54,8 +54,5 @@
     "@types/inquirer": "^9.0.3",
     "inquirer": "^9.1.5",
     "openai": "^3.2.1"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
This pull request adds a new job to the existing GitHub Packages publishing workflow, allowing npm packages to also be published. The new job, "publish-npm", runs on the ubuntu-latest environment and uses the same steps as the "publish-gpr" job, but publishes the package to the npm registry instead of GitHub Packages. The new job is triggered by the completion of the "build" job. The workflow now supports publishing to both GitHub Packages and npm, giving users more options for package distribution.