### PR TITLE
Add "exports" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
     "src"
   ],
   "bin": "dist/cjs/cli.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/gpt-prompts.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "clean": "del dist",
     "pristine": "git clean -xdf && git reset --hard",


### PR DESCRIPTION
This commit adds the "exports" field to package.json, making it
easier to import the package using the new ECMAScript Modules
syntax. Additionally, it provides hints for the types file for
TypeScript users.
