### PR TITLE
Add update-version workflow

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,53 @@
+name: Update Version and Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to update (major/minor/patch)'
+        required: true
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Validate input
+      run: |
+        if [[ "${{ github.event.inputs.version }}" != "major" && "${{ github.event.inputs.version }}" != "minor" && "${{ github.event.inputs.version }}" != "patch" ]]; then
+          echo "Error: Invalid version input. Allowed values are 'major', 'minor', and 'patch'."
+          exit 1
+        fi
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+
+    - name: Install pnpm
+      run: npm install -g pnpm
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Update package.json version
+      id: update-version
+      run: |
+        NEW_VERSION=$(pnpm -r exec -- npx update-version ${{ github.event.inputs.version }})
+        echo "version=$NEW_VERSION" >> $GITHUB_ENV
+
+    - name: Build
+      run: pnpm build
+
+    - name: Commit and push changes
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add .
+        git commit -m "chore: update version to ${{ env.version }}"
+        git push


### PR DESCRIPTION
Add a new GitHub Actions workflow named "Update Version and Build"
that allows updating the package.json version (major, minor, or patch)
on the fly. The workflow triggers manually and validates the input
version before building and pushing the changes.
