### PR TITLE
Add support for ESM and update imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "module": "dist/index.js",
   "types": "dist/gpt-prompts.d.ts",
+  "type": "module",
   "files": [
     "dist",
     "src"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { characterImpersonator } from "./prompts";
-import { Prompt, PromptVariable } from "./types";
+import { characterImpersonator } from "./prompts/index.js";
+import { Prompt, PromptVariable } from "./types.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - This errors for the CJS build but works for the ESM build
 import { type Question } from "inquirer";
-import { parsePrompt } from ".";
+import { parsePrompt } from "./parser.js";
 
 function convertPromptToInquirerQuestions(prompt: Prompt): Question[] {
   return Object.values(prompt.variables).map((variable: PromptVariable) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import * as prompts from "./prompts";
-export * from "./parser";
+import * as prompts from "./prompts/index.js";
+export * from "./parser.js";
 
-export type * from "./types";
+export type * from "./types.js";
 
 export { prompts };

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parsePrompt, parsePromptVariables } from "./parser";
+import { parsePrompt, parsePromptVariables } from "./parser.js";
 
 describe("parsePromptVariables", () => {
   it("should parse variables", () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 import { ChatCompletionRequestMessage } from "openai";
-import { tofu } from "./tofu";
-import { Prompt, PromptResult, PromptVariable } from "./types";
+import { tofu } from "./tofu.js";
+import { Prompt, PromptResult, PromptVariable } from "./types.js";
 
 /**
  * Parses a prompt variable and returns the parsed value.

--- a/src/prompts/character-impersonator.ts
+++ b/src/prompts/character-impersonator.ts
@@ -1,4 +1,4 @@
-import type { Prompt } from "../types";
+import type { Prompt } from "../types.js";
 
 /**
  * Prompt to impersonate a character.

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,1 +1,1 @@
-export * from "./character-impersonator";
+export * from "./character-impersonator.js";


### PR DESCRIPTION
This commit adds `"type": "module"` to the package.json and changes
the extension of imports to `.js` to support ECMAScript modules. It
addresses compatibility issues with different module systems and
ensures the correct usage of ESM.
